### PR TITLE
Fixed printed address on --dump when --address is provided.

### DIFF
--- a/stm32bl.py
+++ b/stm32bl.py
@@ -446,7 +446,7 @@ def main():
         if args.dump or args.read:
             mem = stm32bl.read_memory(address, size)
             if args.dump:
-                stm32bl.print_buffer(Stm32bl.FLASH_START, mem)
+                stm32bl.print_buffer(address, mem)
             if args.read:
                 binfile = open(args.read, 'wb')
                 binfile.write(bytes(mem))


### PR DESCRIPTION
Found this very minor bug when I was using the bootloader to dump memory ranges.  Your code is working great for me.  Thanks!