### PR TITLE
Fixed mass erase

### DIFF
--- a/stm32bl.py
+++ b/stm32bl.py
@@ -278,7 +278,7 @@ class Stm32bl():
             for page in pages:
                 data.append(page)
         else:
-            data = [pages]
+            data = pages
         self._send_data(data, timeout=20)
 
     def _cmd_extended_erase(self, pages=0xffff):


### PR DESCRIPTION
The following happens using --mass-erase with the original code:
:MASS_ERASE
::CMD_ERASE(255)
:::WR: 43:bc
:::RD: 79
:::WR: ff:ff
:::RD: 79

This sequence did not erase the flash of my STM32F103C8T6, it can be validated by the --dump sequence.
The correct mass (global) erase sequence is written in Figure 14 on the Page 22:
https://www.st.com/content/ccc/resource/technical/document/application_note/51/5f/03/1e/bd/9b/45/be/CD00264342.pdf/files/CD00264342.pdf/jcr:content/translations/en.CD00264342.pdf
So it should contain ":::WR: ff:00" instead of ":::WR: ff:ff".

With my fix the _send_data() and the _talk() functions receive "0xff" instead of the "[0xff]", and they treat it as it would a command.
This ensures, that the complement (0x00) is appended, like with any other command, based on this: "for each command the host sends a byte and its complement (XOR = 0x00)" written in the previously mentioned pdf at Page 7 in the "Communication Safety" section.

Other features are working well, thanks for this tool!